### PR TITLE
Optimize _local_timezone() by removing redundant variables

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1994,7 +1994,6 @@ class datetime(date):
         else:
             ts = (self - _EPOCH) // timedelta(seconds=1)
         localtm = _time.localtime(ts)
-        local = datetime(*localtm[:6])
         # Extract TZ data
         gmtoff = localtm.tm_gmtoff
         zone = localtm.tm_zone


### PR DESCRIPTION
## Summary
The `_local_timezone()` method had redundant variables. Optimized logic to improve readability.

### Changes Made
- Removed unnecessary `local` variable assignment
- Maintained identical functionality while reducing code complexity

### Testing
- [x] All existing tests pass: `./python -m test test_datetime`
- [x] No behavioral changes introduced
- [x] `make patchcheck` passes successfully